### PR TITLE
Minor - don't use where

### DIFF
--- a/spectral_lines/spectable.py
+++ b/spectral_lines/spectable.py
@@ -86,7 +86,7 @@ def make_table(region, maskfile, linelist):
         axis = get_axis(cubehead)/1000.0 # km/s
 
         # Retrieve all the structure ids from the mask
-        structids = list(set(mask[np.where(mask >= 0.0)]))
+        structids = list(set(mask[mask >= 0.0]))
         # Prime the table to store the information
         table = generate_table(data_cube, axis, structids)
         # Prime the output file


### PR DESCRIPTION
`x[np.where(condition)]` is redundant.  `x[condition]` does the same and is more efficient